### PR TITLE
Fixes build failure on linux, as discussed in issue #1.

### DIFF
--- a/duktape.go
+++ b/duktape.go
@@ -1,6 +1,8 @@
 package duktape
 
 /*
+#cgo linux LDFLAGS: -lm
+
 # include "duktape.h"
 extern duk_ret_t goFuncCall(duk_context *ctx);
 extern duk_ret_t testFunc(duk_context *ctx);


### PR DESCRIPTION
It adds the appropriate `#cgo` directive to `duktape.go`.

Signed-off-by: Jim Teeuwen <jimteeuwen@gmail.com>