### PR TITLE
PushGoFunc renamed to PushGlobalGoFunction and new PushGoFunction

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import "github.com/olebedev/go-duktape"
 
 func main() {
   ctx := duktape.NewContext()
-  ctx.PushGoFunc("log", func(ctx *duktape.Context) int {
+  ctx.PushGlobalGoFunction("log", func(ctx *duktape.Context) int {
     fmt.Println("Go lang Go!")
     return 0
   })
@@ -51,5 +51,5 @@ The package is not fully tested, so be careful.
 
 ### Contribution
 
-Pull requests are welcome!  
+Pull requests are welcome!
 __Convention:__ fork the repository and make changes on your fork in a feature branch.

--- a/duktape_test.go
+++ b/duktape_test.go
@@ -43,10 +43,10 @@ func TestGoFuncCallWWrongFuncName(t *testing.T) {
 	ctx.DestroyHeap()
 }
 
-func TestGofuncCall(t *testing.T) {
+func TestPushGlobalGoFunction_Call(t *testing.T) {
 	var check bool
 	ctx := Default()
-	ctx.PushGoFunc("test", func(c *Context) int {
+	ctx.PushGlobalGoFunction("test", func(c *Context) int {
 		check = !check
 		return 0
 	})
@@ -61,10 +61,29 @@ func TestGofuncCall(t *testing.T) {
 	ctx.DestroyHeap()
 }
 
+func TestPushGoFunction_Call(t *testing.T) {
+	var check bool
+	ctx := Default()
+	name, err := ctx.PushGoFunction(func(c *Context) int {
+		check = !check
+		return 0
+	})
+
+	expect(t, err, nil)
+	expect(t, len(ctx.fn), 1)
+
+	ctx.EvalString(goFuncCallName + `('` + name + `');`)
+	expect(t, check, true)
+	ctx.EvalString(goFuncCallName + `('` + name + `');`)
+	expect(t, check, false)
+
+	ctx.DestroyHeap()
+}
+
 func TestPopGoFunc(t *testing.T) {
 	var check bool
 	ctx := Default()
-	ctx.PushGoFunc("test", func(c *Context) int {
+	ctx.PushGlobalGoFunction("test", func(c *Context) int {
 		check = !check
 		return 0
 	})
@@ -100,7 +119,7 @@ func goTestfunc(ctx *Context) int {
 
 func TestMyAddTwo(t *testing.T) {
 	ctx := Default()
-	ctx.PushGoFunc("adder", goTestfunc)
+	ctx.PushGlobalGoFunction("adder", goTestfunc)
 	ctx.EvalString(`print("2 + 3 =", adder(2,3))`)
 	ctx.Pop()
 	ctx.EvalString(`adder(2,3)`)


### PR DESCRIPTION
Main changes:

- `PushGoFunc` was renamed to `PushGlobalGoFunction`, to match the convention from the whole API
- Add `PushGoFunction`: allows to push function in any point of the stack (for example in objects)
- Removed eval in favor of `CompileString` less references to the functions
- Comments now follows the Go standard, _function name at the begin of the descriptions_