### PR TITLE
Retuning Error instead int on P* functions

### DIFF
--- a/api.go
+++ b/api.go
@@ -755,55 +755,69 @@ func (d *Context) PcallProp(objIndex int, nargs int) int {
 }
 
 // See: http://duktape.org/api.html#duk_pcompile
-func (d *Context) Pcompile(flags uint) int {
-	return int(C._duk_pcompile(d.duk_context, C.duk_uint_t(flags)))
+func (d *Context) Pcompile(flags uint) error {
+	result := int(C._duk_pcompile(d.duk_context, C.duk_uint_t(flags)))
+	return d.castStringToError(result)
 }
 
 // See: http://duktape.org/api.html#duk_pcompile_file
-func (d *Context) PcompileFile(flags uint, path string) int {
+func (d *Context) PcompileFile(flags uint, path string) error {
 	__path__ := C.CString(path)
 	defer C.free(unsafe.Pointer(__path__))
-	return int(C._duk_pcompile_file(d.duk_context, C.duk_uint_t(flags), __path__))
+
+	result := int(C._duk_pcompile_file(d.duk_context, C.duk_uint_t(flags), __path__))
+	return d.castStringToError(result)
 }
 
 // See: http://duktape.org/api.html#duk_pcompile_lstring
-func (d *Context) PcompileLstring(flags uint, src string, len int) int {
+func (d *Context) PcompileLstring(flags uint, src string, len int) error {
 	__src__ := C.CString(src)
 	defer C.free(unsafe.Pointer(__src__))
-	return int(C._duk_pcompile_lstring(d.duk_context, C.duk_uint_t(flags), __src__, C.duk_size_t(len)))
+
+	result := int(C._duk_pcompile_lstring(d.duk_context, C.duk_uint_t(flags), __src__, C.duk_size_t(len)))
+	return d.castStringToError(result)
 }
 
 // See: http://duktape.org/api.html#duk_pcompile_lstring_filename
-func (d *Context) PcompileLstringFilename(flags uint, src string, len int) int {
+func (d *Context) PcompileLstringFilename(flags uint, src string, len int) error {
 	__src__ := C.CString(src)
 	defer C.free(unsafe.Pointer(__src__))
-	return int(C._duk_pcompile_lstring_filename(d.duk_context, C.duk_uint_t(flags), __src__, C.duk_size_t(len)))
+
+	result := int(C._duk_pcompile_lstring_filename(d.duk_context, C.duk_uint_t(flags), __src__, C.duk_size_t(len)))
+	return d.castStringToError(result)
 }
 
 // See: http://duktape.org/api.html#duk_pcompile_string
-func (d *Context) PcompileString(flags uint, src string) int {
+func (d *Context) PcompileString(flags uint, src string) error {
 	__src__ := C.CString(src)
 	defer C.free(unsafe.Pointer(__src__))
-	return int(C._duk_pcompile_string(d.duk_context, C.duk_uint_t(flags), __src__))
+
+	result := int(C._duk_pcompile_string(d.duk_context, C.duk_uint_t(flags), __src__))
+	return d.castStringToError(result)
 }
 
 // See: http://duktape.org/api.html#duk_pcompile_string_filename
-func (d *Context) PcompileStringFilename(flags uint, src string) int {
+func (d *Context) PcompileStringFilename(flags uint, src string) error {
 	__src__ := C.CString(src)
 	defer C.free(unsafe.Pointer(__src__))
-	return int(C._duk_pcompile_string_filename(d.duk_context, C.duk_uint_t(flags), __src__))
+
+	result := int(C._duk_pcompile_string_filename(d.duk_context, C.duk_uint_t(flags), __src__))
+	return d.castStringToError(result)
 }
 
 // See: http://duktape.org/api.html#duk_peval
-func (d *Context) Peval() int {
-	return int(C._duk_peval(d.duk_context))
+func (d *Context) Peval() error {
+	result := int(C._duk_peval(d.duk_context))
+	return d.castStringToError(result)
 }
 
 // See: http://duktape.org/api.html#duk_peval_file
-func (d *Context) PevalFile(path string) int {
+func (d *Context) PevalFile(path string) error {
 	__path__ := C.CString(path)
 	defer C.free(unsafe.Pointer(__path__))
-	return int(C._duk_peval_file(d.duk_context, __path__))
+
+	result := int(C._duk_peval_file(d.duk_context, __path__))
+	return d.castStringToError(result)
 }
 
 // See: http://duktape.org/api.html#duk_peval_file_noresult
@@ -814,10 +828,13 @@ func (d *Context) PevalFileNoresult(path string) int {
 }
 
 // See: http://duktape.org/api.html#duk_peval_lstring
-func (d *Context) PevalLstring(src string, len int) int {
+func (d *Context) PevalLstring(src string, len int) error {
 	__src__ := C.CString(src)
 	defer C.free(unsafe.Pointer(__src__))
-	return int(C._duk_peval_lstring(d.duk_context, __src__, C.duk_size_t(len)))
+
+	result := int(C._duk_peval_lstring(d.duk_context, __src__, C.duk_size_t(len)))
+	return d.castStringToError(result)
+
 }
 
 // See: http://duktape.org/api.html#duk_peval_lstring_noresult
@@ -833,17 +850,50 @@ func (d *Context) PevalNoresult() int {
 }
 
 // See: http://duktape.org/api.html#duk_peval_string
-func (d *Context) PevalString(src string) int {
+func (d *Context) PevalString(src string) error {
 	__src__ := C.CString(src)
 	defer C.free(unsafe.Pointer(__src__))
-	return int(C._duk_peval_string(d.duk_context, __src__))
+
+	result := int(C._duk_peval_string(d.duk_context, __src__))
+	return d.castStringToError(result)
 }
 
 // See: http://duktape.org/api.html#duk_peval_string_noresult
 func (d *Context) PevalStringNoresult(src string) int {
 	__src__ := C.CString(src)
 	defer C.free(unsafe.Pointer(__src__))
+
 	return int(C._duk_peval_string_noresult(d.duk_context, __src__))
+}
+
+func (d *Context) castStringToError(result int) error {
+	if result == 0 {
+		return nil
+	}
+
+	err := &Error{}
+	for _, key := range []string{"name", "message", "fileName", "lineNumber", "stack"} {
+		d.GetPropString(-1, key)
+
+		switch key {
+		case "name":
+			err.Type = d.SafeToString(-1)
+		case "message":
+			err.Message = d.SafeToString(-1)
+		case "fileName":
+			err.FileName = d.SafeToString(-1)
+		case "lineNumber":
+			if d.IsNumber(-1) {
+				err.LineNumber = d.GetInt(-1)
+			}
+		case "stack":
+			err.Stack = d.SafeToString(-1)
+		}
+
+		d.Pop()
+	}
+
+	return err
 }
 
 // See: http://duktape.org/api.html#duk_pop

--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,27 @@
+package duktape
+
+import (
+	"testing"
+)
+
+func TestPevalString(t *testing.T) {
+	ctx := Default()
+	err := ctx.PevalString("var = 'foo';")
+	expect(t, err.(*Error).Type, "SyntaxError")
+	ctx.DestroyHeap()
+}
+
+func TestPevalFile(t *testing.T) {
+	ctx := Default()
+	err := ctx.PevalFile("foo.js")
+	expect(t, err.(*Error).Message, "no sourcecode")
+	ctx.DestroyHeap()
+}
+
+func TestPcompileString(t *testing.T) {
+	ctx := Default()
+	err := ctx.PcompileString(CompileFunction, "foo")
+	expect(t, err.(*Error).Type, "SyntaxError")
+	expect(t, err.(*Error).LineNumber, 0)
+	ctx.DestroyHeap()
+}

--- a/duktape.go
+++ b/duktape.go
@@ -336,3 +336,15 @@ func (d *Context) pullGoCtx() {
 	d.mu = ctx.mu
 	d.Pop2()
 }
+
+type Error struct {
+	Type       string
+	Message    string
+	FileName   string
+	LineNumber int
+	Stack      string
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s: %s", e.Type, e.Message)
+}


### PR DESCRIPTION
Instead of retuning Ints, now all the P* functions returns a proper Error struct, with Type, Message, FIleName, LineNumber and Stack.
