### PR TITLE
ptr's used to track the golang functions

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -3,21 +3,21 @@ package duktape
 import "testing"
 
 func TestPevalString(t *testing.T) {
-	ctx := Default()
+	ctx := New()
 	err := ctx.PevalString("var = 'foo';")
 	expect(t, err.(*Error).Type, "SyntaxError")
 	ctx.DestroyHeap()
 }
 
 func TestPevalFile(t *testing.T) {
-	ctx := Default()
+	ctx := New()
 	err := ctx.PevalFile("foo.js")
 	expect(t, err.(*Error).Message, "no sourcecode")
 	ctx.DestroyHeap()
 }
 
 func TestPcompileString(t *testing.T) {
-	ctx := Default()
+	ctx := New()
 	err := ctx.PcompileString(CompileFunction, "foo")
 	expect(t, err.(*Error).Type, "SyntaxError")
 	expect(t, err.(*Error).LineNumber, 1)

--- a/conts.go
+++ b/conts.go
@@ -1,0 +1,105 @@
+package duktape
+
+const (
+	CompileEval uint = 1 << iota
+	CompileFunction
+	CompileStrict
+	CompileSafe
+	CompileNoResult
+	CompileNoSource
+	CompileStrlen
+)
+
+const (
+	TypeNone Type = iota
+	TypeUndefined
+	TypeNull
+	TypeBoolean
+	TypeNumber
+	TypeString
+	TypeObject
+	TypeBuffer
+	TypePointer
+	TypeLightFunc
+)
+
+const (
+	TypeMaskNone uint = 1 << iota
+	TypeMaskUndefined
+	TypeMaskNull
+	TypeMaskBoolean
+	TypeMaskNumber
+	TypeMaskString
+	TypeMaskObject
+	TypeMaskBuffer
+	TypeMaskPointer
+	TypeMaskLightFunc
+)
+
+const (
+	EnumIncludeNonenumerable uint = 1 << iota
+	EnumIncludeInternal
+	EnumOwnPropertiesOnly
+	EnumArrayIndicesOnly
+	EnumSortArrayIndices
+	NoProxyBehavior
+)
+
+const (
+	ErrNone int = 0
+
+	// Internal to Duktape
+	ErrUnimplemented int = 50 + iota
+	ErrUnsupported
+	ErrInternal
+	ErrAlloc
+	ErrAssertion
+	ErrAPI
+	ErrUncaughtError
+)
+
+const (
+	// Common prototypes
+	ErrError int = 100 + iota
+	ErrEval
+	ErrRange
+	ErrReference
+	ErrSyntax
+	ErrType
+	ErrURI
+)
+
+const (
+	// Returned error values
+	ErrRetUnimplemented int = -(ErrUnimplemented + iota)
+	ErrRetUnsupported
+	ErrRetInternal
+	ErrRetAlloc
+	ErrRetAssertion
+	ErrRetAPI
+	ErrRetUncaughtError
+)
+
+const (
+	ErrRetError int = -(ErrError + iota)
+	ErrRetEval
+	ErrRetRange
+	ErrRetReference
+	ErrRetSyntax
+	ErrRetType
+	ErrRetURI
+)
+
+const (
+	ExecSuccess = iota
+	ExecError
+)
+
+const (
+	LogTrace int = iota
+	LogDebug
+	LogInfo
+	LogWarn
+	LogError
+	LogFatal
+)

--- a/duktape.go
+++ b/duktape.go
@@ -4,7 +4,7 @@ package duktape
 #cgo linux LDFLAGS: -lm
 
 # include "duktape.h"
-extern duk_ret_t goFuncCall(duk_context *ctx);
+extern duk_ret_t goFunctionCall(duk_context *ctx);
 extern void goFinalizeCall(duk_context *ctx);
 
 */
@@ -12,131 +12,104 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"log"
 	"regexp"
 	"sync"
-	"time"
 	"unsafe"
 )
 
-const (
-	CompileEval uint = 1 << iota
-	CompileFunction
-	CompileStrict
-	CompileSafe
-	CompileNoResult
-	CompileNoSource
-	CompileStrlen
+var (
+	reFuncName = regexp.MustCompile("^[a-z_][a-z0-9_]*([A-Z_][a-z0-9_]*)*$")
+	fnIndex    = newFunctionIndex()
 )
 
-const (
-	TypeNone Type = iota
-	TypeUndefined
-	TypeNull
-	TypeBoolean
-	TypeNumber
-	TypeString
-	TypeObject
-	TypeBuffer
-	TypePointer
-	TypeLightFunc
-)
+const goFunctionPtrProp = "_go_function_ptr"
 
-const (
-	TypeMaskNone uint = 1 << iota
-	TypeMaskUndefined
-	TypeMaskNull
-	TypeMaskBoolean
-	TypeMaskNumber
-	TypeMaskString
-	TypeMaskObject
-	TypeMaskBuffer
-	TypeMaskPointer
-	TypeMaskLightFunc
-)
+type Context struct {
+	duk_context unsafe.Pointer
+}
 
-const (
-	EnumIncludeNonenumerable uint = 1 << iota
-	EnumIncludeInternal
-	EnumOwnPropertiesOnly
-	EnumArrayIndicesOnly
-	EnumSortArrayIndices
-	NoProxyBehavior
-)
+// New returns plain initialized duktape context object
+// See: http://duktape.org/api.html#duk_create_heap_default
+func New() *Context {
+	return &Context{
+		duk_context: C.duk_create_heap(nil, nil, nil, nil, nil),
+	}
+}
 
-const (
-	ErrNone int = 0
+// PushGlobalGoFunction push the given function into duktape global object
+func (d *Context) PushGlobalGoFunction(name string, fn func(*Context) int) error {
+	if !reFuncName.MatchString(name) {
+		return errors.New("Malformed function name '" + name + "'")
+	}
 
-	// Internal to Duktape
-	ErrUnimplemented int = 50 + iota
-	ErrUnsupported
-	ErrInternal
-	ErrAlloc
-	ErrAssertion
-	ErrAPI
-	ErrUncaughtError
-)
+	d.PushGlobalObject()
+	if err := d.PushGoFunction(fn); err != nil {
+		return err
+	}
 
-const (
-	// Common prototypes
-	ErrError int = 100 + iota
-	ErrEval
-	ErrRange
-	ErrReference
-	ErrSyntax
-	ErrType
-	ErrURI
-)
+	d.PutPropString(-2, name)
+	d.Pop()
 
-const (
-	// Returned error values
-	ErrRetUnimplemented int = -(ErrUnimplemented + iota)
-	ErrRetUnsupported
-	ErrRetInternal
-	ErrRetAlloc
-	ErrRetAssertion
-	ErrRetAPI
-	ErrRetUncaughtError
-)
+	return nil
+}
 
-const (
-	ErrRetError int = -(ErrError + iota)
-	ErrRetEval
-	ErrRetRange
-	ErrRetReference
-	ErrRetSyntax
-	ErrRetType
-	ErrRetURI
-)
+// PushGoFunction push the given function into duktape stack
+func (d *Context) PushGoFunction(fn func(*Context) int) error {
+	ptr := fnIndex.Add(fn)
 
-const (
-	ExecSuccess = iota
-	ExecError
-)
+	d.PushCFunction((*[0]byte)(C.goFunctionCall), C.DUK_VARARGS)
+	d.PushCFunction((*[0]byte)(C.goFinalizeCall), 1)
+	d.PushPointer(ptr)
+	d.PutPropString(-2, goFunctionPtrProp)
+	d.SetFinalizer(-2)
 
-const (
-	LogTrace int = iota
-	LogDebug
-	LogInfo
-	LogWarn
-	LogError
-	LogFatal
-)
+	d.PushPointer(ptr)
+	d.PutPropString(-2, goFunctionPtrProp)
 
-const goFuncCallName = "__goFuncCall__"
-const goFinalizeCallName = "__goFinalizeCall__"
-const goCtxName = "__goCtx__"
-const goFunctionHandler = `
-    function(){
-	    return %s.apply(this, ['%s'].concat(Array.prototype.slice.apply(arguments)));
-    };
-`
+	return nil
+}
 
-const goFinalizeHandler = `
-    function(){
-	    %s('%s');
-    };
-`
+//export goFunctionCall
+func goFunctionCall(ctx unsafe.Pointer) C.duk_ret_t {
+	d := &Context{duk_context: ctx}
+	ptr := d.getGoFunctionPtr()
+
+	return C.duk_ret_t(fnIndex.Get(ptr)(d))
+}
+
+//export goFinalizeCall
+func goFinalizeCall(ctx unsafe.Pointer) {
+	d := &Context{duk_context: ctx}
+	ptr := d.getGoFunctionPtr()
+
+	fnIndex.Delete(ptr)
+}
+
+func (d *Context) getGoFunctionPtr() unsafe.Pointer {
+	d.PushCurrentFunction()
+	d.GetPropString(-1, goFunctionPtrProp)
+	defer func() {
+		d.Pop2()
+	}()
+
+	if !d.IsPointer(-1) {
+		return nil
+	}
+
+	return d.GetPointer(-1)
+}
+
+type Error struct {
+	Type       string
+	Message    string
+	FileName   string
+	LineNumber int
+	Stack      string
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s: %s", e.Type, e.Message)
+}
 
 type Type int
 
@@ -178,162 +151,38 @@ func (t Type) String() string {
 	}
 }
 
-type Context struct {
-	duk_context unsafe.Pointer
-	fn          map[string]func(*Context) int
-	mu          sync.Mutex
+type functionIndex struct {
+	functions map[unsafe.Pointer]func(*Context) int
+	sync.Mutex
 }
 
-func New() *Context {
-	panic("Unimplemented")
-}
-
-// Default returns plain initialized duktape context object
-// See: http://duktape.org/api.html#duk_create_heap_default
-func Default() *Context {
-	ctx := &Context{
-		duk_context: C.duk_create_heap(nil, nil, nil, nil, nil),
-		fn:          make(map[string]func(*Context) int),
-	}
-	ctx.defineGoFuncCall()
-	ctx.defineGoFinalizeCall()
-	ctx.pushGoCtx()
-	return ctx
-}
-
-// DEPRICATED
-func NewContext() *Context {
-	log.Println(`
-		duktape.NewContext() is depricated, please use 
-		duktape.New() or duktape.Default() instead
-	`)
-	return Default()
-}
-
-//export goFuncCall
-func goFuncCall(ctx unsafe.Pointer) C.duk_ret_t {
-	d := &Context{duk_context: ctx}
-	d.pullGoCtx()
-
-	// d.PushContextDump()
-	// log.Printf("goCall context: %s", d.GetString(-1))
-	// d.Pop()
-
-	if d.GetTop() == 0 {
-		panic("Go function call without arguments is not supported")
-	}
-	if !d.GetType(0).IsString() {
-		panic("Wrong type of function's key argument")
-	}
-	name := d.GetString(0)
-	if fn, ok := d.fn[name]; ok {
-		r := fn(d)
-		return C.duk_ret_t(r)
-	}
-	panic("Unimplemented")
-}
-
-//export goFinalizeCall
-func goFinalizeCall(ctx unsafe.Pointer) {
-	d := &Context{duk_context: ctx}
-	d.pullGoCtx()
-
-	if d.GetTop() == 0 {
-		panic("Go function call without arguments is not supported")
-	}
-	if !d.GetType(0).IsString() {
-		panic("Wrong type of function's key argument")
-	}
-
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	name := d.GetString(0)
-	if _, ok := d.fn[name]; ok {
-		delete(d.fn, name)
+func newFunctionIndex() *functionIndex {
+	return &functionIndex{
+		functions: make(map[unsafe.Pointer]func(*Context) int, 0),
 	}
 }
 
-var reFuncName = regexp.MustCompile("^[a-z_][a-z0-9_]*([A-Z_][a-z0-9_]*)*$")
+func (i *functionIndex) Add(fn func(*Context) int) unsafe.Pointer {
+	ptr := C.malloc(1)
 
-// PushGlobalGoFunction push the given function into duktape global object
-func (d *Context) PushGlobalGoFunction(name string, fn func(*Context) int) error {
-	if !reFuncName.MatchString(name) {
-		return errors.New("Malformed function name '" + name + "'")
-	}
+	i.Lock()
+	defer i.Unlock()
+	i.functions[ptr] = fn
 
-	d.PushGlobalObject()
-	if err := d.pushGoFunction(name, fn); err != nil {
-		return err
-	}
-
-	d.PutPropString(-2, name)
-	d.Pop()
-
-	return nil
+	return ptr
 }
 
-// PushGoFunction push the given function into duktape stack
-func (d *Context) PushGoFunction(fn func(*Context) int) (string, error) {
-	name := fmt.Sprintf("anon_%d", time.Now().Nanosecond())
-	return name, d.pushGoFunction(name, fn)
+func (i *functionIndex) Get(ptr unsafe.Pointer) func(*Context) int {
+	i.Lock()
+	defer i.Unlock()
+
+	return i.functions[ptr]
 }
 
-func (d *Context) pushGoFunction(name string, fn func(*Context) int) error {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	d.fn[name] = fn
+func (i *functionIndex) Delete(ptr unsafe.Pointer) {
+	i.Lock()
+	defer i.Unlock()
 
-	d.CompileString(CompileFunction, fmt.Sprintf(
-		goFunctionHandler, goFuncCallName, name,
-	))
-
-	d.CompileString(CompileFunction, fmt.Sprintf(
-		goFinalizeHandler, goFinalizeCallName, name,
-	))
-
-	d.SetFinalizer(-2)
-	return nil
-}
-
-func (d *Context) defineGoFuncCall() {
-	d.PushGlobalObject()
-	d.PushCFunction((*[0]byte)(C.goFuncCall), int(C.DUK_VARARGS))
-	d.PutPropString(-2, goFuncCallName)
-	d.Pop()
-}
-
-func (d *Context) defineGoFinalizeCall() {
-	d.PushGlobalObject()
-	d.PushCFunction((*[0]byte)(C.goFinalizeCall), int(C.DUK_VARARGS))
-	d.PutPropString(-2, goFinalizeCallName)
-	d.Pop()
-}
-
-func (d *Context) pushGoCtx() {
-	d.PushGlobalObject()
-	d.PushPointer(unsafe.Pointer(d))
-	d.PutPropString(-2, goCtxName)
-	d.Pop()
-}
-
-func (d *Context) pullGoCtx() {
-	d.PushGlobalObject()
-	d.GetPropString(-1, goCtxName)
-	ctx := (*Context)(d.GetPointer(-1))
-	d.fn = ctx.fn
-	d.mu = ctx.mu
-	d.Pop2()
-}
-
-type Error struct {
-	Type       string
-	Message    string
-	FileName   string
-	LineNumber int
-	Stack      string
-}
-
-func (e *Error) Error() string {
-	return fmt.Sprintf("%s: %s", e.Type, e.Message)
+	delete(i.functions, ptr)
+	C.free(ptr)
 }

--- a/duktape_test.go
+++ b/duktape_test.go
@@ -6,102 +6,74 @@ import (
 )
 
 func TestEvalString(t *testing.T) {
-	ctx := Default()
+	ctx := New()
 	ctx.EvalString(`"Golang love Duktape!"`)
 	expect(t, Type(ctx.GetType(-1)).IsString(), true)
 	expect(t, ctx.GetString(-1), "Golang love Duktape!")
 	ctx.DestroyHeap()
 }
 
-func TestGoFuncCallWOArgs(t *testing.T) {
-	defer func() {
-		r := recover()
-		expect(t, r, "Go function call without arguments is not supported")
-	}()
-	ctx := Default()
-	ctx.EvalString(goFuncCallName + `();`)
-	ctx.DestroyHeap()
-}
-
-func TestGoFuncCallWWrongArg(t *testing.T) {
-	defer func() {
-		r := recover()
-		expect(t, r, "Wrong type of function's key argument")
-	}()
-	ctx := Default()
-	ctx.EvalString(goFuncCallName + `(0); // first argument must be a string`)
-	ctx.DestroyHeap()
-}
-
-func TestGoFuncCallWWrongFuncName(t *testing.T) {
-	defer func() {
-		r := recover()
-		expect(t, r, "Unimplemented")
-	}()
-	ctx := Default()
-	ctx.EvalString(goFuncCallName + `('noFunctionName'); // this func is not defined`)
-	ctx.DestroyHeap()
-}
-
 func TestPushGlobalGoFunction_Call(t *testing.T) {
 	var check bool
-	ctx := Default()
+	ctx := New()
 	ctx.PushGlobalGoFunction("test", func(c *Context) int {
 		check = !check
 		return 0
 	})
-	expect(t, len(ctx.fn), 1)
-	for k, _ := range ctx.fn {
-		ctx.EvalString(goFuncCallName + `('` + k + `');`)
-		expect(t, check, true)
-		ctx.EvalString(goFuncCallName + `('` + k + `');`)
-		expect(t, check, false)
-		break
-	}
+
+	expect(t, len(fnIndex.functions), 1)
+	ctx.EvalString("test();")
+	expect(t, check, true)
+	ctx.EvalString("test();")
+	expect(t, check, false)
 
 	ctx.DestroyHeap()
 }
 
 func TestPushGlobalGoFunction_Finalize(t *testing.T) {
-	ctx := Default()
+	ctx := New()
 	ctx.PushGlobalGoFunction("test", func(c *Context) int {
 		return 0
 	})
 
-	expect(t, len(ctx.fn), 1)
+	expect(t, len(fnIndex.functions), 1)
 	ctx.EvalString("test = undefined")
 	ctx.Gc(0)
-	expect(t, len(ctx.fn), 0)
+	expect(t, len(fnIndex.functions), 0)
 
 	ctx.DestroyHeap()
 }
 
 func TestPushGoFunction_Call(t *testing.T) {
 	var check bool
-	ctx := Default()
-	name, err := ctx.PushGoFunction(func(c *Context) int {
+	ctx := New()
+	ctx.PushGlobalObject()
+	err := ctx.PushGoFunction(func(c *Context) int {
 		check = !check
 		return 0
 	})
 
-	expect(t, err, nil)
-	expect(t, len(ctx.fn), 1)
+	ctx.PutPropString(-2, "test")
+	ctx.Pop()
 
-	ctx.EvalString(goFuncCallName + `('` + name + `');`)
+	expect(t, err, nil)
+	expect(t, len(fnIndex.functions), 1)
+
+	ctx.EvalString("test();")
 	expect(t, check, true)
-	ctx.EvalString(goFuncCallName + `('` + name + `');`)
+	ctx.EvalString("test();")
 	expect(t, check, false)
 
 	ctx.DestroyHeap()
 }
 
 func TestErrorObj(t *testing.T) {
-	ctx := Default()
+	ctx := New()
 	defer ctx.DestroyHeap()
 	ctx.PushErrorObject(ErrType, "Got an error thingy: ", 5)
 	expectError(t, ctx, ErrType, "TypeError: Got an error thingy: 5")
 
-	ctx = Default()
+	ctx = New()
 	defer ctx.DestroyHeap()
 	ctx.PushErrorObjectf(ErrURI, "Got an error thingy: %x", 0xdeadbeef)
 	expectError(t, ctx, ErrURI, "URIError: Got an error thingy: deadbeef")
@@ -116,7 +88,7 @@ func goTestfunc(ctx *Context) int {
 }
 
 func TestMyAddTwo(t *testing.T) {
-	ctx := Default()
+	ctx := New()
 	ctx.PushGlobalGoFunction("adder", goTestfunc)
 	ctx.EvalString(`print("2 + 3 =", adder(2,3))`)
 	ctx.Pop()

--- a/duktape_test.go
+++ b/duktape_test.go
@@ -21,7 +21,7 @@ func TestPushGlobalGoFunction_Call(t *testing.T) {
 		return 0
 	})
 
-	expect(t, len(fnIndex.functions), 1)
+	expect(t, len(fnIndexes[ctx.duk_context].functions), 1)
 	ctx.EvalString("test();")
 	expect(t, check, true)
 	ctx.EvalString("test();")
@@ -36,10 +36,10 @@ func TestPushGlobalGoFunction_Finalize(t *testing.T) {
 		return 0
 	})
 
-	expect(t, len(fnIndex.functions), 1)
+	expect(t, len(fnIndexes[ctx.duk_context].functions), 1)
 	ctx.EvalString("test = undefined")
 	ctx.Gc(0)
-	expect(t, len(fnIndex.functions), 0)
+	expect(t, len(fnIndexes[ctx.duk_context].functions), 0)
 
 	ctx.DestroyHeap()
 }
@@ -57,7 +57,7 @@ func TestPushGoFunction_Call(t *testing.T) {
 	ctx.Pop()
 
 	expect(t, err, nil)
-	expect(t, len(fnIndex.functions), 1)
+	expect(t, len(fnIndexes[ctx.duk_context].functions), 1)
 
 	ctx.EvalString("test();")
 	expect(t, check, true)


### PR DESCRIPTION
- JS wrapper remove now the Go function is tracking with a ptr attached as a property to the function. heavy inspired by @ivan4th at https://github.com/ivan4th/go-duktape/blob/master/duktape.go
- the functions are not stored any more on `Context` a `functionIndex ` is used handling the mutex and the ptr malloc and free
- const are now in a spare file 
- `Default` has gone `New` is a empty contexts