### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/duktape.go
+++ b/duktape.go
@@ -2,6 +2,7 @@ package duktape
 
 /*
 #cgo linux LDFLAGS: -lm
+#cgo freebsd LDFLAGS: -lm
 
 # include "duktape.h"
 extern duk_ret_t goFunctionCall(duk_context *ctx);


### PR DESCRIPTION
The math import was missing.

```
higgs~/go/src/gopkg.in/olebedev/go-duktape.v2(master|✔) % git rev-parse HEAD
f4bc69da3f943e2f5c939d02da9ddaff90fee7a7
higgs~/go/src/gopkg.in/olebedev/go-duktape.v2(master|✔) % go build -v       
gopkg.in/olebedev/go-duktape.v2
# gopkg.in/olebedev/go-duktape.v2
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk_js_tointeger_number':
./duk_js_ops.c:268: undefined reference to `floor'
./duk_js_ops.c:268: undefined reference to `floor'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk__toint32_touint32_helper':
./duk_js_ops.c:298: undefined reference to `floor'
./duk_js_ops.c:307: undefined reference to `fmod'
./duk_js_ops.c:298: undefined reference to `floor'
./duk_js_ops.c:307: undefined reference to `fmod'
./duk_js_ops.c:298: undefined reference to `floor'
./duk_js_ops.c:307: undefined reference to `fmod'
./duk_js_ops.c:298: undefined reference to `floor'
./duk_js_ops.c:307: undefined reference to `fmod'
./duk_js_ops.c:298: undefined reference to `floor'
./duk_js_ops.c:307: undefined reference to `fmod'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk__compute_mod':
./duk_js_executor.c:35: undefined reference to `fmod'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk_bi_date_get_now_gettimeofday':
./duk_js_ops.c:268: undefined reference to `floor'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk_js_tointeger_number':
./duk_js_ops.c:268: undefined reference to `floor'
./duk_js_ops.c:268: undefined reference to `floor'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk__fmax_fixed':
./duk_bi_math.c:83: undefined reference to `fmax'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk__fmin_fixed':
./duk_bi_math.c:65: undefined reference to `fmin'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk_to_uint8clamped':
./duk_api_stack.c:2042: undefined reference to `floor'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk_js_tointeger_number':
./duk_js_ops.c:268: undefined reference to `floor'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk__atan2':
./duk_bi_math.c:235: undefined reference to `atan2'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk__pow_fixed':
./duk_bi_math.c:188: undefined reference to `pow'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk__acos':
./duk_bi_math.c:202: undefined reference to `acos'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk__asin':
./duk_bi_math.c:205: undefined reference to `asin'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk__atan':
./duk_bi_math.c:208: undefined reference to `atan'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk(char,...)(int, long)':
./duk_bi_math.c:211: undefined reference to `ceil'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk__cos':
./duk_bi_math.c:214: undefined reference to `cos'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk(...)(long long,  *)':
./duk_bi_math.c:217: undefined reference to `exp'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk__floor':
./duk_bi_math.c:220: undefined reference to `floor'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk__log':
./duk_bi_math.c:223: undefined reference to `log'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk__round_fixed':
./duk_bi_math.c:127: undefined reference to `floor'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk__sin':
./duk_bi_math.c:226: undefined reference to `sin'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk__tan':
./duk_bi_math.c:232: undefined reference to `tan'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk_bi_date_timeval_to_parts':
./duk_bi_date.c:638: undefined reference to `fmod'
./duk_bi_date.c:643: undefined reference to `floor'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk__traceback_getter_helper':
./duk_bi_error.c:158: undefined reference to `fmod'
./duk_bi_error.c:159: undefined reference to `floor'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk_js_tointeger_number':
./duk_js_ops.c:268: undefined reference to `floor'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk__make_day':
./duk_bi_date.c:562: undefined reference to `floor'
./duk_bi_date.c:564: undefined reference to `fmod'
/tmp/go-build492726023/gopkg.in/olebedev/go-duktape.v2/_obj/duktape.o: In function `duk_js_tointeger_number':
./duk_js_ops.c:268: undefined reference to `floor'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```