### PR TITLE
Add memory leak info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ func main() {
   result := ctx.GetNumber(-1)
   ctx.Pop()
   fmt.Println("result is:", result)
+  // To prevent memory leaks, don't forget to clean up after 
+  // yourself when you're done using a context.
+  ctx.DestroyHeap()
 }
 ```
 


### PR DESCRIPTION
I'm using `go-duktape` to evaluate thousands of JS strings coming from a message queue every minute, with a consumer that creates a new duktape context for each message. My app was blowing up the memory after just a few minutes. Spent a week tracking down the bug and finally read the `go-duktape` source code and found `DestroyHeap()` which was exactly what I needed. It could be very useful to have at the top of the documentation :) Now my app is humming along at a few MB
