### PR TITLE
Expose duk_require_callable & duk_require_function

### DIFF
--- a/api.go
+++ b/api.go
@@ -1170,9 +1170,21 @@ func (d *Context) RequireBuffer(index int, outSize int) {
 	C.duk_require_buffer(d.duk_context, C.duk_idx_t(index), (*C.duk_size_t)(unsafe.Pointer(&outSize)))
 }
 
+// See: http://duktape.org/api.html#duk_require_callable
+func (d *Context) RequireCallable(index int) {
+	// At present, duk_require_callable is a macro that just calls duk_require_function.
+	// cgo does not support such macros we have to call it directly.
+	C.duk_require_function(d.duk_context, C.duk_idx_t(index))
+}
+
 // See: http://duktape.org/api.html#duk_require_context
 func (d *Context) RequireContext(index int) *Context {
 	return contextFromPointer(C.duk_require_context(d.duk_context, C.duk_idx_t(index)))
+}
+
+// See: http://duktape.org/api.html#duk_require_function
+func (d *Context) RequireFunction(index int) {
+	C.duk_require_function(d.duk_context, C.duk_idx_t(index))
 }
 
 // See: http://duktape.org/api.html#duk_require_heapptr
@@ -1594,6 +1606,4 @@ func (d *Context) PushExternalBuffer() {
  * StealBuffer see: http://duktape.org/api.html#duk_steal_buffer
  * RequireBufferData see: http://duktape.org/api.html#duk_require_buffer_data
  * IsEvalError see: http://duktape.org/api.html#duk_is_eval_error
- * RequireFunction see: http://duktape.org/api.html#duk_require_function
- * RequireCallable see: http://duktape.org/api.html#duk_require_callable
  */


### PR DESCRIPTION
Both duk_require_callable & duk_require_function are useful for testing that a JavaScript callback function has been specified as an argument to a bound Golang function. They are not currently available from this library.

Both functions do not return a value (they both have a void return type):

> There is no "get" primitive (duk_get_callable()) because there's no useful C return value for an arbitrary callable value. At the moment this call is equivalent to calling duk_require_function(). 

> There is no "get" primitive (duk_get_function()) because there's no useful C return value for an arbitrary function.

So there is no conversion from C function pointers to Golang functions required.