### PR TITLE
Enable console flushing

### DIFF
--- a/duk_console.h
+++ b/duk_console.h
@@ -6,6 +6,9 @@
 /* Use a proxy wrapper to make undefined methods (console.foo()) no-ops. */
 #define DUK_CONSOLE_PROXY_WRAPPER  (1 << 0)
 
+/* Flush output after every call. */
+#define DUK_CONSOLE_FLUSH          (1 << 1)
+
 extern void duk_console_init(duk_context *ctx, duk_uint_t flags);
 
 #endif  /* DUK_CONSOLE_H_INCLUDED */

--- a/duktape.go
+++ b/duktape.go
@@ -66,6 +66,42 @@ func New() *Context {
 	return d
 }
 
+// Flags is a set of flags for controlling the behaviour of duktape.
+type Flags struct {
+	Logging    uint
+	PrintAlert uint
+	Console    uint
+}
+
+// FlagConsoleProxyWrapper is a Console flag.
+// Use a proxy wrapper to make undefined methods (console.foo()) no-ops.
+const FlagConsoleProxyWrapper = 1 << 0
+
+// FlagConsoleFlush is a Console flag.
+// Flush output after every call.
+const FlagConsoleFlush = 1 << 1
+
+// NewWithFlags returns plain initialized duktape context object
+// You can control the behaviour of duktape by setting flags.
+// See: http://duktape.org/api.html#duk_create_heap_default
+func NewWithFlags(flags *Flags) *Context {
+	d := &Context{
+		&context{
+			duk_context: C.duk_create_heap(nil, nil, nil, nil, nil),
+			fnIndex:     newFunctionIndex(),
+			timerIndex:  &timerIndex{},
+		},
+	}
+
+	ctx := d.duk_context
+	C.duk_logging_init(ctx, C.duk_uint_t(flags.Logging))
+	C.duk_print_alert_init(ctx, C.duk_uint_t(flags.PrintAlert))
+	C.duk_module_duktape_init(ctx)
+	C.duk_console_init(ctx, C.duk_uint_t(flags.Console))
+
+	return d
+}
+
 func contextFromPointer(ctx *C.duk_context) *Context {
 	return &Context{&context{duk_context: ctx}}
 }


### PR DESCRIPTION
Integrate some changes made to the console extra in `duktape`:

https://github.com/svaarala/duktape/pull/1587
https://github.com/svaarala/duktape/pull/1588

This allows a user of `go-duktape` to optionally enable the console flushing flag, which will flush the buffers after every `console.log()` - I need this because the buffering makes it hard for our users to use `console.log()` as a debugging tool. I am not enabling this by default as I am sure it will negatively impact the performance for all users that do not require this functionality.

Since `go-duktape` has not exposed the flags options before, I have added in a new type `Flags` (to hold the flags) and a new API method `NewWithFlags` that accepts a set of `Flags`. This allows a VM to be started with:

`vm := duktape.NewWithFlags(&duktape.Flags{Console: duktape.FlagConsoleFlush})`