### PR TITLE
fix for go 1.9 compiler error constant 18446744073709551615 overflows int

### DIFF
--- a/duktape.h
+++ b/duktape.h
@@ -281,7 +281,7 @@ struct duk_time_components {
 /* Indicates that a native function does not have a fixed number of args,
  * and the argument stack should not be capped/extended at all.
  */
-#define DUK_VARARGS                       ((duk_int_t) (-1))
+#define DUK_VARARGS                       ((duk_uint_t) (-1))
 
 /* Number of value stack entries (in addition to actual call arguments)
  * guaranteed to be allocated on entry to a Duktape/C function.


### PR DESCRIPTION
github.com/olebedev/go-duktape/duktape.go:131: constant 18446744073709551615 overflows int