### PR TITLE
Fixed Err.. constants

### DIFF
--- a/conts.go
+++ b/conts.go
@@ -60,7 +60,7 @@ const (
 
 const (
 	// Common prototypes
-	ErrError int = 1
+	ErrError int = 1 + iota
 	ErrEval
 	ErrRange
 	ErrReference


### PR DESCRIPTION
Added a missing `+ iota` so that the `Err...` constants again match those declared in `duktape.h`.