### PR TITLE
Fix "constant 18446744073709551615 overflows int" errors

### DIFF
--- a/duktape.go
+++ b/duktape.go
@@ -80,7 +80,8 @@ func (d *Context) PushGoFunction(fn func(*Context) int) int {
 	funPtr := d.fnIndex.add(fn)
 	ctxPtr := contexts.add(d)
 
-	idx := d.PushCFunction((*[0]byte)(C.goFunctionCall), C.DUK_VARARGS)
+	DUK_VARARGS := int(^uint(0) >> 1)
+	idx := d.PushCFunction((*[0]byte)(C.goFunctionCall), DUK_VARARGS)
 	d.PushCFunction((*[0]byte)(C.goFinalizeCall), 1)
 	d.PushPointer(funPtr)
 	d.PutPropString(-2, goFunctionPtrProp)


### PR DESCRIPTION
**Fixes the following errors:**
```
olebedev\go-duktape.v2\duktape.go:83: constant 18446744073709551615 overflows int
olebedev\go-duktape.v2\duktape.go:87: constant 18446744073709551615 overflows int
```

**OS/Machine:**
- Windows 10, 64-bit, Home Edition,

**The problem:**
ducktape.h uses #define for this value, i.e
`#define DUK_VARARGS ((duk_int_t) (-1))`

My assumption is that the Golang compiler assumes this is Uint/Uint64 rather than Int/Int64. Not sure if there's a more robust way to solve this.