### PR TITLE
Fix DUK_VARARGS C -> Go overflow issue for all platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: go
+go_import_path: gopkg.in/olebedev/go-duktape.v3
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      go: 1.9.x
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+      script:
+        # Build and test on the native 64 bit architecture
+        - go get -t
+        - go install ./...
+        - go test ./...
+
+        # Switch over GCC to cross compilation (breaks 386, hence why do it here only)
+        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install gcc-arm-linux-gnueabi libc6-dev-armel-cross gcc-arm-linux-gnueabihf libc6-dev-armhf-cross gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+        - sudo ln -s /usr/include/asm-generic /usr/include/asm
+
+        # Build only on non-native 32 bit, ARM and MIPS architectures
+        - CGO_ENABLED=1 GOARCH=386 go install ./...
+        - CGO_ENABLED=1 GOARCH=arm GOARM=5 CC=arm-linux-gnueabi-gcc go install ./...
+        - CGO_ENABLED=1 GOARCH=arm GOARM=6 CC=arm-linux-gnueabi-gcc go install ./...
+        - CGO_ENABLED=1 GOARCH=arm GOARM=7 CC=arm-linux-gnueabihf-gcc go install ./...
+        - CGO_ENABLED=1 GOARCH=arm64 CC=aarch64-linux-gnu-gcc go install ./...
+
+    - os: osx
+      go: 1.9.x
+      script:
+        # Build and test on the native 64 bit architecture
+        - go get -t
+        - go install ./...
+        - go test ./...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Duktape bindings for Go(Golang) [![wercker status](https://app.wercker.com/status/3a5bb2e639a4b4efaf4c8bf7cab7442d/s "wercker status")](https://app.wercker.com/project/bykey/3a5bb2e639a4b4efaf4c8bf7cab7442d) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/olebedev/go-duktape?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+# Duktape bindings for Go(Golang)
+
+[![wercker status](https://app.wercker.com/status/3a5bb2e639a4b4efaf4c8bf7cab7442d/s "wercker status")](https://app.wercker.com/project/bykey/3a5bb2e639a4b4efaf4c8bf7cab7442d)
+[![Travis status](https://travis-ci.org/olebedev/go-duktape.svg?branch=v3)](https://travis-ci.org/olebedev/go-duktape)
+[![Appveyor status](https://ci.appveyor.com/api/projects/status/github/olebedev/go-duktape?branch=v3&svg=true)](https://ci.appveyor.com/project/olebedev/go-duktape/branch/v3)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/olebedev/go-duktape?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
 [Duktape](http://duktape.org/index.html) is a thin, embeddable javascript engine.
 Most of the [api](http://duktape.org/api.html) is implemented.
 The exceptions are listed [here](https://github.com/olebedev/go-duktape/blob/master/api.go#L1566).
@@ -21,7 +27,7 @@ func main() {
   result := ctx.GetNumber(-1)
   ctx.Pop()
   fmt.Println("result is:", result)
-  // To prevent memory leaks, don't forget to clean up after 
+  // To prevent memory leaks, don't forget to clean up after
   // yourself when you're done using a context.
   ctx.DestroyHeap()
 }

--- a/api.go
+++ b/api.go
@@ -973,7 +973,7 @@ func (d *Context) PushBuffer(size int, dynamic bool) unsafe.Pointer {
 }
 
 // See: http://duktape.org/api.html#duk_push_c_function
-func (d *Context) PushCFunction(fn *[0]byte, nargs int) int {
+func (d *Context) PushCFunction(fn *[0]byte, nargs int64) int {
 	return int(C.duk_push_c_function(d.duk_context, fn, C.duk_idx_t(nargs)))
 }
 

--- a/api_test.go
+++ b/api_test.go
@@ -31,7 +31,7 @@ func (s *DuktapeSuite) TestPushErrorObject(c *C) {
 }
 
 func (s *DuktapeSuite) TestPushErrorObjectVa(c *C) {
-	s.ctx.PushErrorObjectVa(ErrURI, "Got an error thingy: %x %s %s", 0xdeadbeef, "is", "tasty")
+	s.ctx.PushErrorObjectVa(ErrURI, "Got an error thingy: %x %s %s", int64(0xdeadbeef), "is", "tasty")
 	s.assertErrorInCtx(c, ErrURI, "URIError: Got an error thingy: deadbeef is tasty")
 }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,34 @@
+os: Visual Studio 2015
+
+clone_folder: C:\gopath\src\gopkg.in/olebedev/go-duktape.v3
+clone_depth: 5
+version: "{branch}.{build}"
+environment:
+  global:
+    GOPATH: C:\gopath
+    CC: gcc.exe
+  matrix:
+    - DUKTAPE_ARCH: amd64
+      MSYS2_ARCH: x86_64
+      MSYS2_BITS: 64
+      MSYSTEM: MINGW64
+      PATH: C:\msys64\mingw64\bin\;C:\Program Files (x86)\NSIS\;%PATH%
+    - DUKTAPE_ARCH: 386
+      MSYS2_ARCH: i686
+      MSYS2_BITS: 32
+      MSYSTEM: MINGW32
+      PATH: C:\msys64\mingw32\bin\;C:\Program Files (x86)\NSIS\;%PATH%
+
+install:
+  - rmdir C:\go /s /q
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.9.2.windows-%DUKTAPE_ARCH%.zip
+  - 7z x go1.9.2.windows-%DUKTAPE_ARCH%.zip -y -oC:\ > NUL
+  - go version
+  - gcc --version
+
+build_script:
+  - go get -t
+  - go install ./...
+
+test_script:
+  - go test ./...

--- a/duktape.h
+++ b/duktape.h
@@ -284,7 +284,7 @@ struct duk_time_components {
 /* Indicates that a native function does not have a fixed number of args,
  * and the argument stack should not be capped/extended at all.
  */
-#define DUK_VARARGS                       ((duk_uint_t) (-1))
+#define DUK_VARARGS                       ((duk_int_t) (-1))
 
 /* Number of value stack entries (in addition to actual call arguments)
  * guaranteed to be allocated on entry to a Duktape/C function.


### PR DESCRIPTION
Originally `go-duktape` used the [exact code from the upstream repo](https://github.com/svaarala/duktape/blob/master/src-input/duktape.h.in#L171) in the [declaration of the `DUK_VARARGS`](https://github.com/olebedev/go-duktape/blob/v3/duktape.h#L287):

```c
#define DUK_VARARGS                       ((duk_int_t) (-1))
```

This was wrapped into an `int` in the [Go wrapper code](https://github.com/olebedev/go-duktape/blob/v3/duktape.go#L132):

```go
idx := d.PushCFunction((*[0]byte)(C.goFunctionCall), C.DUK_VARARGS)
```

```go
func (d *Context) PushCFunction(fn *[0]byte, nargs int) int
```

This looked kind of ok, but for some reason broke on Windows builds with **`gopkg.in\olebedev\go-duktape.v3\duktape.go:132: constant 18446744073709551615 overflows int`**, so https://github.com/olebedev/go-duktape/pull/53 fixed it by changing the type of `DUK_VARARGS` from `duk_int_t` to `duk_uint_t`. Windows builds passed, everyone was happy.

Unfortunately all 32 bit platforms (386, arm, mips32) blow up now with **`gopkg.in/olebedev/go-duktape.v3/duktape.go:132: constant 4294967295 overflows int`**. Apparently there was something very weird happening with `duk_int_t` and `duk_uint_t` within the C code, causing wildly different interpretations on different platforms.

---

Taking a closer look into the [definition of `duk_int_t` to `duk_uint_t`](https://github.com/olebedev/go-duktape/blob/v3/duk_config.h#L1955), they boil down to these lines of code (excerpt):

```c
/* The best type for an "all around int" in Duktape internals is "at least
 * 32 bit signed integer" which is most convenient.  Same for unsigned type.
 * Prefer 'int' when large enough, as it is almost always a convenient type.
 */
#if defined(UINT_MAX) && (UINT_MAX >= 0xffffffffUL)
    typedef int duk_int_t;
    typedef unsigned int duk_uint_t;
#else
    typedef duk_int_fast32_t duk_int_t;
    typedef duk_uint_fast32_t duk_uint_t;
#endif

[...]

typedef int_fast32_t duk_int_fast32_t;
typedef uint_fast32_t duk_uint_fast32_t;
```

I.e. Depending on various platform, architecture and libc specifics, `duk_int_t` might be either an `int` or `int_fast32_t` (similar for the unsigned version). If it resolves to a plain `int` the types match with Go, and everything compiles correctly.

If however `duk_int_t` resolves to `int_fast32_t`, all hell breaks loose, since it's a funky non-fixed sized type defined in the CPP reference as:

> fastest signed integer type with width of at least 32 bits

This means, that `int_fast32_t` is only guaranteed to be **at least** 32 bits, but may be larger on given platform/architectures if those lead to better performance due to operations with native CPU types.

The reason duktape has all these strange type overflow issues on different platforms is because `DUK_VARARGS` might actually be a 64 bit integer, even though it looks innocuous as a 32 bit int only.

---

This PR fixes the issue by reverting the `DUK_VARARGS` to its upstream version of ` ((duk_int_t) (-1))`, and changes the receiver type for this value from Go `int` to `int64`. This fixes the build on all platforms. In addition it also fixes a type case in one of the tests on 32 bit platforms.

In addition, a second commit enables running the tests and builds on Linux, OSX and Windows on 32/64 bits and various ARM architectures to ensure they won't break in the future. Travis and appveyor should just be pointed to these files and they will pick up everything without any manual configuration.

 * https://travis-ci.org/karalabe/go-duktape/builds/319080617
 * https://ci.appveyor.com/project/karalabe/go-duktape/build/fix-386-overflow.13