### PR TITLE
Fix compiler warning with -Wno-unused-value

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,8 +1,8 @@
 package duktape
 
 /*
-#cgo !windows CFLAGS: -std=c99 -O3 -Wall -fomit-frame-pointer -fstrict-aliasing
-#cgo windows CFLAGS: -O3 -Wall -fomit-frame-pointer -fstrict-aliasing
+#cgo !windows CFLAGS: -std=c99 -O3 -Wall -Wno-unused-value -fomit-frame-pointer -fstrict-aliasing
+#cgo windows CFLAGS: -O3 -Wall -Wno-unused-value -fomit-frame-pointer -fstrict-aliasing
 
 #include "duktape.h"
 #include "duk_logging.h"


### PR DESCRIPTION
This PR hides a compiler note that makes it hard to read logs on projects that rely on go-duktape.

In file included from ./api.go:7:0:
```
./api.go: In function ‘_duk_error’:
./duktape.h:510:127: warning: right-hand operand of comma expression has no effect [-Wunused-value]
  (duk_error_raw((ctx), (duk_errcode_t) (err_code), (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__), (duk_ret_t) 0)
                                                                                                                               ^
./api.go:153:2: note: in expansion of macro ‘duk_error’
  duk_error(ctx, err_code, "%s", str);
  ^
```