### PR TITLE
Use DUK_SIZE_MAX instead of SIZE_MAX in duk_minimal_printf

### DIFF
--- a/duk_minimal_printf.c
+++ b/duk_minimal_printf.c
@@ -5,7 +5,7 @@
 
 #include <stdarg.h>  /* va_list etc */
 #include <stddef.h>  /* size_t */
-#include <stdint.h>  /* SIZE_MAX */
+#include "duk_config.h"
 
 /* Write character with bound checking.  Offset 'off' is updated regardless
  * of whether an actual write is made.  This is necessary to satisfy snprintf()
@@ -283,7 +283,7 @@ int duk_minimal_sprintf(char *str, const char *format, ...) {
 	int ret;
 
 	va_start(ap, format);
-	ret = duk_minimal_vsnprintf(str, SIZE_MAX, format, ap);
+	ret = duk_minimal_vsnprintf(str, DUK_SIZE_MAX, format, ap);
 	va_end(ap);
 
 	return ret;


### PR DESCRIPTION
When cross compiling to android with `xgo`, there is a compile error, because `SIZE_MAX` is missing from `stdint.h`. This fixes that (an alternative solution would be to use `limits.h` on android).

Compile output:
```
% xgo -targets=android-16/aar -v github.com/olebedev/go-duktape 
Checking docker installation...
Client:
 Version:	17.12.0-ce
 API version:	1.35
 Go version:	go1.9.2
 Git commit:	c97c6d6
 Built:	Wed Dec 27 20:03:51 2017
 OS/Arch:	darwin/amd64

Server:
 Engine:
  Version:	17.12.0-ce
  API version:	1.35 (minimum version 1.12)
  Go version:	go1.9.2
  Git commit:	c97c6d6
  Built:	Wed Dec 27 20:12:29 2017
  OS/Arch:	linux/amd64
  Experimental:	true

Checking for required docker image karalabe/xgo-latest... found.
Cross compiling github.com/olebedev/go-duktape...
Fetching main repository github.com/olebedev/go-duktape...
github.com/olebedev/go-duktape (download)
Assembling toolchain for android-16/arm...
Bootstrapping android-16/arm...
Assembling toolchain for android-16/arm...
Bootstrapping android-16/arm...
Compiling for android-16/arm...
# github.com/olebedev/go-duktape
duk_minimal_printf.c: In function 'duk_minimal_sprintf':
duk_minimal_printf.c:286:35: error: 'SIZE_MAX' undeclared (first use in this function)
  ret = duk_minimal_vsnprintf(str, SIZE_MAX, format, ap);
                                   ^
duk_minimal_printf.c:286:35: note: each undeclared identifier is reported only once for each function it appears in
```