### PR TITLE
Constants and api fixes

### DIFF
--- a/api.go
+++ b/api.go
@@ -821,8 +821,7 @@ func (d *Context) PcompileString(flags uint, src string) error {
 	__src__ := C.CString(src)
 	result := int(C._duk_pcompile_string(d.duk_context, C.duk_uint_t(flags), __src__))
 	C.free(unsafe.Pointer(__src__))
-	fmt.Println("result herhehreh", result)
-	return nil //d.castStringToError(result)
+	return d.castStringToError(result)
 }
 
 // See: http://duktape.org/api.html#duk_pcompile_string_filename

--- a/conts.go
+++ b/conts.go
@@ -1,72 +1,75 @@
 package duktape
 
+/*
+#cgo !windows CFLAGS: -std=c99 -O3 -Wall -Wno-unused-value -fomit-frame-pointer -fstrict-aliasing
+#cgo windows CFLAGS: -O3 -Wall -Wno-unused-value -fomit-frame-pointer -fstrict-aliasing
+
+#include "duktape.h"
+*/
+import "C"
+
 const (
-	CompileEval uint = 1 << iota
-	CompileFunction
-	CompileStrict
-	CompileSafe
-	CompileNoResult
-	CompileNoSource
-	CompileStrlen
+	CompileEval       uint = C.DUK_COMPILE_EVAL
+	CompileFunction   uint = C.DUK_COMPILE_FUNCTION
+	CompileStrict     uint = C.DUK_COMPILE_STRICT
+	CompileShebang    uint = C.DUK_COMPILE_SHEBANG
+	CompileSafe       uint = C.DUK_COMPILE_SAFE
+	CompileNoResult   uint = C.DUK_COMPILE_NORESULT
+	CompileNoSource   uint = C.DUK_COMPILE_NOSOURCE
+	CompileStrlen     uint = C.DUK_COMPILE_STRLEN
+	CompileNoFileName uint = C.DUK_COMPILE_NOFILENAME
+	CompileFuncExpr   uint = C.DUK_COMPILE_FUNCEXPR
 )
 
 const (
-	TypeNone Type = iota
-	TypeUndefined
-	TypeNull
-	TypeBoolean
-	TypeNumber
-	TypeString
-	TypeObject
-	TypeBuffer
-	TypePointer
-	TypeLightFunc
+	TypeNone      Type = C.DUK_TYPE_NONE
+	TypeUndefined Type = C.DUK_TYPE_UNDEFINED
+	TypeNull      Type = C.DUK_TYPE_NULL
+	TypeBoolean   Type = C.DUK_TYPE_BOOLEAN
+	TypeNumber    Type = C.DUK_TYPE_NUMBER
+	TypeString    Type = C.DUK_TYPE_STRING
+	TypeObject    Type = C.DUK_TYPE_OBJECT
+	TypeBuffer    Type = C.DUK_TYPE_BUFFER
+	TypePointer   Type = C.DUK_TYPE_POINTER
+	TypeLightFunc Type = C.DUK_TYPE_LIGHTFUNC
 )
 
 const (
-	TypeMaskNone uint = 1 << iota
-	TypeMaskUndefined
-	TypeMaskNull
-	TypeMaskBoolean
-	TypeMaskNumber
-	TypeMaskString
-	TypeMaskObject
-	TypeMaskBuffer
-	TypeMaskPointer
-	TypeMaskLightFunc
+	TypeMaskNone      uint = C.DUK_TYPE_MASK_NONE
+	TypeMaskUndefined uint = C.DUK_TYPE_MASK_UNDEFINED
+	TypeMaskNull      uint = C.DUK_TYPE_MASK_NULL
+	TypeMaskBoolean   uint = C.DUK_TYPE_MASK_BOOLEAN
+	TypeMaskNumber    uint = C.DUK_TYPE_MASK_NUMBER
+	TypeMaskString    uint = C.DUK_TYPE_MASK_STRING
+	TypeMaskObject    uint = C.DUK_TYPE_MASK_OBJECT
+	TypeMaskBuffer    uint = C.DUK_TYPE_MASK_BUFFER
+	TypeMaskPointer   uint = C.DUK_TYPE_MASK_POINTER
+	TypeMaskLightFunc uint = C.DUK_TYPE_MASK_LIGHTFUNC
 )
 
 const (
-	EnumIncludeNonenumerable uint = 1 << iota
-	EnumIncludeInternal
-	EnumOwnPropertiesOnly
-	EnumArrayIndicesOnly
-	EnumSortArrayIndices
-	NoProxyBehavior
+	EnumIncludeNonenumerable uint = C.DUK_ENUM_INCLUDE_NONENUMERABLE
+	EnumIncludeHidden        uint = C.DUK_ENUM_INCLUDE_HIDDEN
+	EnumIncludeSymbols       uint = C.DUK_ENUM_INCLUDE_SYMBOLS
+	EnumExcludeStrings       uint = C.DUK_ENUM_EXCLUDE_STRINGS
+	EnumOwnPropertiesOnly    uint = C.DUK_ENUM_OWN_PROPERTIES_ONLY
+	EnumArrayIndicesOnly     uint = C.DUK_ENUM_ARRAY_INDICES_ONLY
+	EnumSortArrayIndices     uint = C.DUK_ENUM_SORT_ARRAY_INDICES
+	NoProxyBehavior          uint = C.DUK_ENUM_NO_PROXY_BEHAVIOR
 )
 
 const (
-	ErrNone int = 0
-
-	// Internal to Duktape
 	ErrUnimplemented int = 50 + iota
 	ErrUnsupported
-	ErrInternal
-	ErrAlloc
-	ErrAssertion
-	ErrAPI
-	ErrUncaughtError
-)
 
-const (
-	// Common prototypes
-	ErrError int = 1 + iota
-	ErrEval
-	ErrRange
-	ErrReference
-	ErrSyntax
-	ErrType
-	ErrURI
+	ErrNone      int = C.DUK_ERR_NONE
+	ErrError     int = C.DUK_ERR_ERROR
+	ErrEval      int = C.DUK_ERR_EVAL_ERROR
+	ErrRange     int = C.DUK_ERR_RANGE_ERROR
+	ErrReference int = C.DUK_ERR_REFERENCE_ERROR
+	ErrSyntax    int = C.DUK_ERR_SYNTAX_ERROR
+	ErrType      int = C.DUK_ERR_TYPE_ERROR
+	ErrURI       int = C.DUK_ERR_URI_ERROR
 )
 
 const (
@@ -81,18 +84,18 @@ const (
 )
 
 const (
-	ErrRetError int = -(ErrError + iota)
-	ErrRetEval
-	ErrRetRange
-	ErrRetReference
-	ErrRetSyntax
-	ErrRetType
-	ErrRetURI
+	ErrRetError     int = -(ErrError)
+	ErrRetEval      int = -(ErrEval)
+	ErrRetRange     int = -(ErrRange)
+	ErrRetReference int = -(ErrReference)
+	ErrRetSyntax    int = -(ErrSyntax)
+	ErrRetType      int = -(ErrType)
+	ErrRetURI       int = -(ErrURI)
 )
 
 const (
-	ExecSuccess = iota
-	ExecError
+	ExecSuccess int = C.DUK_EXEC_SUCCESS
+	ExecError   int = C.DUK_EXEC_ERROR
 )
 
 const (
@@ -105,17 +108,16 @@ const (
 )
 
 const (
-	BufobjDuktapeAuffer     = 0
-	BufobjNodejsAuffer      = 1
-	BufobjArraybuffer       = 2
-	BufobjDataview          = 3
-	BufobjInt8array         = 4
-	BufobjUint8array        = 5
-	BufobjUint8clampedarray = 6
-	BufobjInt16array        = 7
-	BufobjUint16array       = 8
-	BufobjInt32array        = 9
-	BufobjUint32array       = 10
-	BufobjFloat32array      = 11
-	BufobjFloat64array      = 12
+	BufObjArrayBuffer       int = C.DUK_BUFOBJ_ARRAYBUFFER
+	BufObjNodejsBuffer      int = C.DUK_BUFOBJ_NODEJS_BUFFER
+	BufObjDataView          int = C.DUK_BUFOBJ_DATAVIEW
+	BufobjInt8Array         int = C.DUK_BUFOBJ_INT8ARRAY
+	BufobjUint8Array        int = C.DUK_BUFOBJ_UINT8ARRAY
+	BufobjUint8ClampedArray int = C.DUK_BUFOBJ_UINT8CLAMPEDARRAY
+	BufObjInt16Array        int = C.DUK_BUFOBJ_INT16ARRAY
+	BufObjUint16Array       int = C.DUK_BUFOBJ_UINT16ARRAY
+	BufObjInt32Array        int = C.DUK_BUFOBJ_INT32ARRAY
+	BufObjUint32Array       int = C.DUK_BUFOBJ_UINT32ARRAY
+	BufObjFloat32Array      int = C.DUK_BUFOBJ_FLOAT32ARRAY
+	BufObjFloat64Array      int = C.DUK_BUFOBJ_FLOAT64ARRAY
 )

--- a/duktape.go
+++ b/duktape.go
@@ -199,7 +199,7 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("%s: %s", e.Type, e.Message)
 }
 
-type Type int
+type Type uint
 
 func (t Type) IsNone() bool      { return t == TypeNone }
 func (t Type) IsUndefined() bool { return t == TypeUndefined }


### PR DESCRIPTION
Hi @olebedev, thanks for the fine library!

This PR fixes inconsistencies between go-duktape and duktape constants by using them from duktape directly, which will be easier to maintain in the long-term. It also fixes PcompileString to return the actual error and removes a debug print.