### PR TITLE
logging: Format the timestamp using unsigned year, month, etc.

### DIFF
--- a/duk_logging.c
+++ b/duk_logging.c
@@ -181,10 +181,11 @@ static duk_ret_t duk__logger_prototype_log_shared(duk_context *ctx) {
 
 	now = duk_get_now(ctx);
 	duk_time_to_components(ctx, now, &comp);
-	sprintf((char *) date_buf, "%04d-%02d-%02dT%02d:%02d:%02d.%03dZ",
-	        (int) comp.year, (int) comp.month + 1, (int) comp.day,
-	        (int) comp.hours, (int) comp.minutes, (int) comp.seconds,
-	        (int) comp.milliseconds);
+	sprintf((char *) date_buf, "%04u-%02u-%02uT%02u:%02u:%02u.%03uZ",
+	        (unsigned int) comp.year, (unsigned int) comp.month + 1,
+	        (unsigned int) comp.day, (unsigned int) comp.hours,
+	        (unsigned int) comp.minutes, (unsigned int) comp.seconds,
+	        (unsigned int) comp.milliseconds);
 
 	date_len = strlen((const char *) date_buf);
 


### PR DESCRIPTION
This fixes a compiler warning about the buffer length

```
$ go version
go version go1.13.8 linux/amd64
$ go build
...
duk_logging.c: In function ‘duk__logger_prototype_log_shared’:
duk_logging.c:184:64: warning: ‘Z’ directive writing 1 byte into a
region of size between 0 and 9 [-Wformat-overflow=]
184 |  sprintf((char *) date_buf,
"%04d-%02d-%02dT%02d:%02d:%02d.%03dZ",
      |                                                                ^
In file included from /usr/include/stdio.h:867,
                 from duk_logging.c:5:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note:
‘__builtin___sprintf_chk’ output between 25 and 85 bytes into a
destination of size 32
   36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   37 |       __bos (__s), __fmt, __va_arg_pack ());
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```