### PR TITLE
debugger, duktape: DragonflyBSD build support

### DIFF
--- a/debugger.go
+++ b/debugger.go
@@ -6,6 +6,7 @@ package duktape
 #cgo linux LDFLAGS: -lm
 #cgo freebsd LDFLAGS: -lm
 #cgo openbsd LDFLAGS: -lm
+#cgo dragonfly LDFLAGS: -lm
 
 #include "duktape.h"
 #include <stdbool.h>

--- a/duktape.go
+++ b/duktape.go
@@ -6,6 +6,7 @@ package duktape
 #cgo linux LDFLAGS: -lm
 #cgo freebsd LDFLAGS: -lm
 #cgo openbsd LDFLAGS: -lm
+#cgo dragonfly LDFLAGS: -lm
 
 #include "duktape.h"
 #include "duk_logging.h"


### PR DESCRIPTION
Add the necessary `LDFLAG` switches to get duktape to build on Dragonfly BSD